### PR TITLE
manual-publish - add '--pull-always' to be sure latest images from remote repo gets pulled for build

### DIFF
--- a/manual-publish.sh
+++ b/manual-publish.sh
@@ -10,7 +10,7 @@ build_tag_push() {
     FROM_IMAGE_NAME=$2
 
     echo BUILD: ${IMAGE_NAME}
-    podman build --build-arg FROM_IMAGE=${REGISTRY_URI}/${REGISTRY_REPOSITORY}/${FROM_IMAGE_NAME}:${IMAGE_VERSION} --tag ${IMAGE_NAME} ${IMAGE_NAME}
+    podman build --build-arg FROM_IMAGE=${REGISTRY_URI}/${REGISTRY_REPOSITORY}/${FROM_IMAGE_NAME}:${IMAGE_VERSION} --tag ${IMAGE_NAME} --pull-always ${IMAGE_NAME}
 
     for IMAGE_TAG in ${IMAGE_TAGS}; do
         FULL_TAG="${REGISTRY_URI}/${REGISTRY_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}"


### PR DESCRIPTION
## issue
 when running the `./manual-publish.sh` script if you have a local copy of the tssc-base image tagged with the upstream tag that the manually built images are dependent on, then `podman build` uses that cached image tag rather then pulling latest from remote repo.

when merging and then publishing the manual images for https://github.com/rhtconsulting/tssc-containers/pull/26 this meant that the buildah image ended up using a locally cached version of tssc-base which didn't have the required changes and then caused failures during integration testing.

## resolution
set the `--pull-always` flag on the `podman build` command to be sure that the remote images are always pulled even if there is a local image.