### PR TITLE
NAPSSPO-1033 - Install a default version of TSSC in the base container

### DIFF
--- a/tssc-base/Dockerfile.ubi8
+++ b/tssc-base/Dockerfile.ubi8
@@ -3,6 +3,7 @@ ARG TSSC_USER_NAME=tssc
 ARG TSSC_USER_UID=1001
 ARG TSSC_USER_GID=0
 ARG TSSC_HOME_DIR=/home/tssc
+ARG TSSC_SOURCE=git+https://github.com/rhtconsulting/tssc-python-package.git@main
 
 ##############################################
 # Stage 1 : Retrieive oc cli
@@ -17,6 +18,7 @@ ARG TSSC_USER_NAME
 ARG TSSC_USER_UID
 ARG TSSC_USER_GID
 ARG TSSC_HOME_DIR
+ARG TSSC_SOURCE
 COPY --from=origin-cli /usr/bin/oc /usr/bin/oc
 COPY --from=origin-cli /usr/bin/kubectl /usr/bin/kubectl
 
@@ -52,7 +54,10 @@ RUN INSTALL_PKGS="gettext git rsync tar unzip which zip bzip2 python36 python3-p
 
 # Configure Python
 RUN alternatives --set python /usr/bin/python3 && \
-    python -m pip install --upgrade pip
+    python -m pip install --no-cache-dir --upgrade pip
+
+# Install TSSC python library
+RUN pip install --no-cache-dir --upgrade ${TSSC_SOURCE}
 
 # Configure tssc user
 RUN useradd tssc --uid $TSSC_USER_UID --gid $TSSC_USER_GID --home-dir ${TSSC_HOME_DIR} --create-home --shell /sbin/nologin && \


### PR DESCRIPTION
#### What is this PR About?
Currently, the Jenkins pipeline downloads the TSSC python code from the Internet every time it runs. In disconnected environments, we want the pipeline to instead use a pre-installed copy of the TSSC python code that is baked into the image.

This PR adds the pre-installed copy of tssc-python-library.

#### Related:
https://github.com/rhtconsulting/tssc-jenkins-library/pull/14 - Add an option to use the baked in copy or install a newer version.

#### Test Results:
Disconnected use case: https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-12/56/console
Connected use case: https://jenkins-jenkins.apps.tssc.rht-set.com/job/tssc-references/job/reference-quarkus-mvn-jenkins/view/change-requests/job/PR-12/57/console