### PR TITLE
tssc-tool-helm - change HELM_PLUGINS to /helm/plugins so any user canuse them

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -756,8 +756,14 @@ jobs:
           echo "Check helm version (this value needs to be updated if default value in container is updated)"
           docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} version
 
+          echo "Check helm-secrets plugin is installed in expected location"
+          docker run -u 1001 --entrypoint='' ${{ env.IMAGE_TAG_LOCAL }} /bin/sh -c "ls /helm/plugins/helm-secrets"
+
           echo "Check that helm-secrets plugin is installed"
           docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} secrets --help
+
+          echo "Check that helm-secrets plugin is installed when running as random user"
+          docker run -u 10010042 ${{ env.IMAGE_TAG_LOCAL }} secrets --help
 
           echo "Check that sops is installed"
           docker run -u 1001 --entrypoint='' ${{ env.IMAGE_TAG_LOCAL }} /bin/sh -c "sops --version"

--- a/tssc-base/Dockerfile.ubi8
+++ b/tssc-base/Dockerfile.ubi8
@@ -46,7 +46,7 @@ RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -
     chmod +x /usr/bin/jq
 
 # Install packages
-RUN INSTALL_PKGS="gettext git rsync tar unzip which zip bzip2 python36 python3-pip python3-pip-wheel python3-setuptools python36-devel ${SOPS_RPM}" && \
+RUN INSTALL_PKGS="gettext git rsync tar unzip which zip bzip2 python36 python3-pip python3-pip-wheel python3-setuptools python36-devel ${SOPS_RPM} gnupg2" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     dnf update -y && \
     rpm -V $INSTALL_PKGS && \

--- a/tssc-tool-helm/Dockerfile.ubi8
+++ b/tssc-tool-helm/Dockerfile.ubi8
@@ -1,9 +1,14 @@
 ARG FROM_IMAGE=quay.io/tssc/tssc-base:latest
-ARG HELM_VERSION=v3.3.4
 
-FROM $FROM_IMAGE
+ARG HELM_PLUGINS_DIR=/helm/plugins
+ARG HELM_VERSION=v3.3.4
+ARG HELM_PLUGIN_HELM_SECRETS_VERSION=v2.0.2
+
+FROM ${FROM_IMAGE}
 ARG TSSC_USER_UID
 ARG HELM_VERSION
+ARG HELM_PLUGINS_DIR
+ARG HELM_PLUGIN_HELM_SECRETS_VERSION
 
 LABEL com.redhat.component="tssc-tool-helm" \
       name="tssc/tssc-tool-helm" \
@@ -16,13 +21,21 @@ LABEL com.redhat.component="tssc-tool-helm" \
 USER 0
 
 # download HELM and install in /usr/local/bin
-RUN curl -L https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz -o helm-$HELM_VERSION-linux-amd64.tar.gz && \
-    tar -zxvf helm-$HELM_VERSION-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/local/bin/helm
+RUN curl -L https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm-${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -zxvf helm-$HELM_VERSION-linux-amd64.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin/helm
 
 # install the sops plugin for helm
-RUN helm plugin install https://github.com/zendesk/helm-secrets
+# NOTE: the trick of setting and unsetting XDG_DATA_HOME seems to be documented no where but
+#	also seems to be the only way to get the plugins to actually install in the right playce
+#	Found trick here: https://jenkins-x.io/community/labs/enhancements/proposals/4/readme/#231-quick-and-dirty-implementation
+RUN mkdir -p ${HELM_PLUGINS_DIR} && \
+    chmod a+rwx ${HELM_PLUGINS_DIR}
+ENV HELM_PLUGINS=${HELM_PLUGINS_DIR}
+RUN export XDG_DATA_HOME="/" \
+    && helm plugin install https://github.com/zendesk/helm-secrets --version ${HELM_PLUGIN_HELM_SECRETS_VERSION} \
+    && unset XDG_DATA_HOME
 
-USER $TSSC_USER_UID
+USER ${TSSC_USER_UID}
 
 ENTRYPOINT [ "/usr/local/bin/helm" ]


### PR DESCRIPTION
# Issue
currently the helm-secrets plugin is getting installed in /home/tssc/.local/blabla. Problem is if ever running as another user then you can't access the plugin there.

# Solution
set HELM_PLUGINS environment variable so plugins get installed and loaded from there.
