### PR TITLE
NAPSSPO-347 - tssc-tool-openscap/Dockerfile.ubi8 - no longer install scap-security-guide rpm content

### DIFF
--- a/tssc-tool-openscap/Dockerfile.ubi8
+++ b/tssc-tool-openscap/Dockerfile.ubi8
@@ -11,7 +11,6 @@ LABEL com.redhat.component="tssc-tool-image-scanner" \
       io.openshift.tags="openshift,image-scanner,python,python3,python36" \
       maintainer="napsspo+tssc@redhat.com"
 
-# https://github.com/mbach04/image-scanner
-ENV INSTALL_PKGS="scap-security-guide openscap-scanner"
+ENV INSTALL_PKGS="openscap-scanner"
 RUN dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS \
     && dnf clean all --enablerepo=\*


### PR DESCRIPTION
# issue

currently we install the `scap-security-guide` rpm which supplies oscap compliance profiles to `/usr/share/xml/scap/ssg/content` as part of the `tssc-tool-openscap` container image. The problem is that now teams may reference that content in an old copy of this image which then means the compliance data is out of date. the workflow should assume all content is coming from other sources and not baked into the CI tool images.

# solution

dont install `scap-security-guide` rpm.
for "connected" users they can reference https://atopathways.redhatgov.io/compliance-as-code/scap/ which has a super set of the input files and profiles installed form the `scap-security-guide` rpm.

For "disconnected" users they can either
a) use golie (https://www.redhat.com/en/blog/red-hat-adopts-rolie-protocol-automated-exchange-security-compliance-assets) to mirror the content of https://atopathways.redhatgov.io/compliance-as-code/scap/ to an internal mirror
OR
b) mirror the source content repo (https://github.com/ComplianceAsCode/content) into the disconnected environment and then build the content in the disconnected environment, and then host that content in the disconnected environment
OR
c) build custom content that is hosted in the disconnected environmnt
OR
d) any combination of any of that

TL;DR put hte responsbility of hosting the compliance and vulnerability content on the enviornment and not on the CI tool.