### PR TITLE
tssc-base - install tssc pip module via 'python -m pip install' rather then 'pip install'

### DIFF
--- a/tssc-base/Dockerfile.ubi8
+++ b/tssc-base/Dockerfile.ubi8
@@ -57,7 +57,7 @@ RUN alternatives --set python /usr/bin/python3 && \
     python -m pip install --no-cache-dir --upgrade pip
 
 # Install TSSC python library
-RUN pip install --no-cache-dir --upgrade ${TSSC_SOURCE}
+RUN python -m pip install --no-cache-dir --upgrade ${TSSC_SOURCE}
 
 # Configure tssc user
 RUN useradd tssc --uid $TSSC_USER_UID --gid $TSSC_USER_GID --home-dir ${TSSC_HOME_DIR} --create-home --shell /sbin/nologin && \


### PR DESCRIPTION
# issue
the tssc-tool-maven:latest image isn't able to find the `tssc` module

# fix
not sure why this fixes it but swapping `pip install` for `python -m pip install` fixes the issue.